### PR TITLE
fixes and tweaks for install.sh

### DIFF
--- a/assets/facebookmessenger.desktop
+++ b/assets/facebookmessenger.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Facebook Messenger
+Icon=/opt/MessengerForDesktop/icon_1024.png
+Exec=/opt/MessengerForDesktop/Messenger
+Comment=Facebook Messenger
+Categories=Network;
+Terminal=false

--- a/assets/install.sh
+++ b/assets/install.sh
@@ -4,12 +4,17 @@ if [ "$(whoami)" != "root" ]; then
 	echo "Run as root if you get 'Permission denied' errors."
 fi
 
-mkdir -p /usr/share/MessengerForDesktop
-yes | cp -rf ./* /usr/share/MessengerForDesktop/
+mkdir -p /opt/MessengerForDesktop
+cp -rf ./* /opt/MessengerForDesktop/
+chmod -R 755 /opt/MessengerForDesktop
+chmod +x /opt/MessengerForDesktop/facebookmessenger.desktop
+cp -f /opt/MessengerForDesktop/facebookmessenger.desktop /usr/share/applications/
+chmod +x /opt/MessengerForDesktop/Messenger
+chmod 644 /usr/share/applications/facebookmessenger.desktop
 
 read -p "Add a shortcut to Messenger on your Desktop? [yN]" yn
 
 case $yn in
-  [Yy]* ) ln -s /usr/share/MessengerForDesktop/Messenger $HOME/Desktop/Messenger;;
+  [Yy]* ) cp /opt/MessengerForDesktop/facebookmessenger.desktop $HOME/Desktop;;
   [Nn]* ) exit;;
 esac


### PR DESCRIPTION
The Linux installer doesn't work properly: the files are installed with the wrong permissions and I couldn't even open the /usr/share/MessengerForDesktop folder. I tried to improve the installer, here's what I did:
- install "MessengerForDesktop" in /opt/ instead of /usr/share/ (there's nothing shared...)
- use proper file permissions
- add a "desktop" file with an icon so the app shows up in the menu / can be pinned to the taskbar (Unity Launcher, etc.) - this assumes that the "/icon_1024.png" icon is available with the .run package.