### PR TITLE
Fix blinking badge for non-English users, fixes #63

### DIFF
--- a/src/components/window-behaviour.js
+++ b/src/components/window-behaviour.js
@@ -108,11 +108,15 @@ module.exports = {
    */
   syncBadge: function(win, doc) {
     var notifCountRegex = /\((\d)\)/;
-    var keepStateRegex = /.*messaged you.*/;
+    var keepStateRegex = /Messenger/;
 
     setInterval(function() {
-      if (keepStateRegex.test(doc.title)) {
-        // This prevents the badge from blinking at the same time with the title
+      if (!keepStateRegex.test(doc.title)) {
+        /*
+         * This prevents the badge from blinking at the same time with the title,
+         * when the title says “{name} messaged you” and not in the form of
+         * “(1) Messenger”.
+         */
         return;
       }
 


### PR DESCRIPTION
When someone messaged you when Messenger is in background, the title blinks between the following 2 forms:

- “(1) Messenger”
- “{name} messaged you”

In window-behaviour.js L111, it tries to parse out the “messaged you” from the title to prevent badge blink.
However for non-English users, this fails because the specified phrase does not exists in page title.

Therefore I'm trying the opposite way. If you cannot find the word “Messenger” in page title, I assume that
it's biinking for the unread message.