### PR TITLE
Removed bugs involving full screen mode on OS X

### DIFF
--- a/src/components/window-behaviour.js
+++ b/src/components/window-behaviour.js
@@ -18,11 +18,14 @@ module.exports = {
     if (!platform.isLinux) {
       win.removeAllListeners('close');
       win.on('close', function(quit) {
-        if (quit) {
+	// Fullscreen apps on OSX must close to prevent black screen
+	if (platform.isOSX && win.isFullscreen) { quit = true; }
+
+        if (quit) {	  
           this.saveWindowState(win);
           win.close(true);
         } else {
-          win.hide();
+	  win.hide();
         }
       }.bind(this));
     }
@@ -145,6 +148,7 @@ module.exports = {
       state.y = win.y;
       state.width = win.width;
       state.height = win.height;
+      state.isFullscreen = win.isFullscreen;
     }
 
     settings.windowState = state;
@@ -158,11 +162,11 @@ module.exports = {
 
     if (state.mode == 'maximized') {
       win.maximize();
-    } else {
+    }
+    else if(!state.isFullscreen) { //Don't restore to fullscreen
       win.resizeTo(state.width, state.height);
       win.moveTo(state.x, state.y);
     }
-
     win.show();
   }
-};
+}


### PR DESCRIPTION
On my OS X Yosemite machine, there were a couple bugs involving full screen mode. 

When the app was closed while in full screen mode, the window size/position was saved for the next restart. That meant that upon reopening the app, the app opened occupying the entire screen, but not in full screen mode--the close/minimize/maximize buttons were not visible. To fix this, I set the app to never open with maximized full screen dimensions.

Additionally, when the window was closed in full screen mode, the app remains open leaving a black workspace. I fixed this by simply terminating the entire application (rather than just the window) when closed in full screen mode.