### PR TITLE
Double shortcut fix #189, Build directory fix on win32 build.

### DIFF
--- a/assets-windows/installer.nsi
+++ b/assets-windows/installer.nsi
@@ -2,6 +2,7 @@
 
 Name "Messenger"
 BrandingText "aluxian.com"
+RequestExecutionLevel "admin"
 
 # set the icon
 !define MUI_ICON "icon.ico"
@@ -24,7 +25,8 @@ InstallDir "$PROGRAMFILES\Messenger for Desktop\"
 
 # default section start
 Section
-
+  # set the current shell context to the current users
+  SetShellVarContext "current"
   # delete the installed files
   RMDir /r $INSTDIR
 
@@ -38,21 +40,22 @@ Section
   WriteUninstaller "$INSTDIR\Uninstall Messenger for Desktop.exe"
 
   # create shortcuts in the start menu and on the desktop
-  CreateShortCut "$SMPROGRAMS\Messenger.lnk" "$INSTDIR\Messenger.exe"
-  CreateShortCut "$SMPROGRAMS\Uninstall Messenger for Desktop.lnk" "$INSTDIR\Uninstall Messenger for Desktop.exe"
+  CreateShortCut "$APPDATA\Microsoft\Windows\Start Menu\Programs\Messenger.lnk" "$INSTDIR\Messenger.exe"
+  CreateShortCut "$APPDATA\Microsoft\Windows\Start Menu\Programs\Uninstall Messenger for Desktop.lnk" "$INSTDIR\Uninstall Messenger for Desktop.exe"
   CreateShortCut "$DESKTOP\Messenger.lnk" "$INSTDIR\Messenger.exe"
 
 SectionEnd
 
 # create a section to define what the uninstaller does
 Section "Uninstall"
-
+  # set the current shell context to the current users
+  SetShellVarContext "current"
   # delete the installed files
   RMDir /r $INSTDIR
 
   # delete the shortcuts
-  Delete "$SMPROGRAMS\Messenger.lnk"
-  Delete "$SMPROGRAMS\Uninstall Messenger for Desktop.lnk"
+  Delete "$APPDATA\Microsoft\Windows\Start Menu\Programs\Messenger.lnk"
+  Delete "$APPDATA\Microsoft\Windows\Start Menu\Programs\Uninstall Messenger for Desktop.lnk"
   Delete "$DESKTOP\Messenger.lnk"
 
 SectionEnd

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -69,6 +69,7 @@ gulp.task 'pack:osx64', ['sign:osx64'], ->
 
 # Create a nsis installer for win32; must have `makensis` installed
 gulp.task 'pack:win32', ['build:win32'], ->
+   shelljs.mkdir '-p', './dist'            # makensis fails if ./dist doesn't exist
    shelljs.exec 'makensis ./assets-windows/installer.nsi'
 
 # Create packages for linux


### PR DESCRIPTION
Fixed: Aluxian/Facebook-Messenger-Desktop#189
+ the build directory is needed for makensis.exe to work.