### PR TITLE
Add closeWithEscKey setting

### DIFF
--- a/src/components/menus.js
+++ b/src/components/menus.js
@@ -94,6 +94,10 @@ module.exports = {
       label: 'Theme',
       submenu: this.createThemesMenu(keep)
     }, {
+      type: 'checkbox',
+      label: 'Close with ESC key',
+      setting: 'closeWithEscKey'
+    }, {
       type: 'separator'
     }, {
       label: 'Check for Update',

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -8,6 +8,7 @@ var DEFAULT_SETTINGS = {
   openLinksInBrowser: true,
   autoHideSidebar: false,
   asMenuBarAppOSX: false,
+  closeWithEscKey: true,
   windowState: {},
   theme: 'default'
 };

--- a/src/components/window-behaviour.js
+++ b/src/components/window-behaviour.js
@@ -33,7 +33,7 @@ module.exports = {
    */
   closeWithEscKey: function(win, doc) {
     doc.onkeyup = function(e) {
-      if (e.keyCode == 27) {
+      if (e.keyCode == 27 && settings.closeWithEscKey) {
         e.preventDefault();
         win.close();
         return false;


### PR DESCRIPTION
Add setting to allow the enabling / disabling of closing the window using the ESC key. It is set to `true` by default. Fixes #208.