### PR TITLE
Make sure the window gets focused

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,11 @@ var windowBehaviour = require('./components/window-behaviour');
 var notification = require('./components/notification');
 var dispatcher = require('./components/dispatcher');
 
+// Make sure the window gets focused
+setTimeout(function(){
+  win.focus();
+}, 500);
+
 // Ensure there's an app shortcut for toast notifications to work on Windows
 if (platform.isWindows) {
   gui.App.createShortcut(process.env.APPDATA + "\\Microsoft\\Windows\\Start Menu\\Programs\\Messenger.lnk");


### PR DESCRIPTION
I am on OSX Yosemite with nw 0.12.2, and when the window is not focusd without a win.focus()
When I tried, I also found it needed a `setTimeout` delay.
However, on Windows it works well.
Let's make sure the window gets focus ;)