### PR TITLE
Fix top header user name color to gray

### DIFF
--- a/assets-linux/messengerfordesktop.desktop
+++ b/assets-linux/messengerfordesktop.desktop
@@ -6,4 +6,5 @@ Icon=messengerfordesktop
 Exec=/opt/MessengerForDesktop/Messenger
 Comment=Messenger for Desktop
 Categories=Network;Chat;
-Terminal=false
+Terminal=false;
+StartupWMClass=MessengerForDesktop

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -185,6 +185,6 @@ div._4-i2, div._5a8u {
 
 /* stuff that should be grey */
 ._ih3, ._3tl0, ._3tl1 ._10w4, ._1htf, ._497p, ._3x6v, ._2v6o, ._3tky, ._5rh4, ._jf4 ._jf3, ._haj .__6m, ._2y8z,
-._4g0h, ._3xcx, ._225b, ._3q35 {
+._4g0h, ._3xcx, ._225b, ._3q35, ._3oh-, ._3eus{
 	color: rgba(255, 255, 255, .6) !important;
 }

--- a/src/themes/mosaic.css
+++ b/src/themes/mosaic.css
@@ -39,9 +39,8 @@ a {
 }
 
 /* Top header user status */
-._2v6o {
-  color: inherit;
-  opacity: 0.6;
+._2v6o, ._3oh-, ._3eus {
+  color: rgba(255, 255, 255, .6) !important;
 }
 
 /* People names */


### PR DESCRIPTION
Initially the user name color was black, now it is gray as it should be.