### PR TITLE
Make some text easier to read in Mosaic theme

### DIFF
--- a/src/themes/mosaic.css
+++ b/src/themes/mosaic.css
@@ -155,3 +155,13 @@ a {
 ._4_j4 time {
   color: #dcdccc !important;
 }
+
+/* Header Person/Group name */
+._3oh {
+  color: #DCDCCC !important;
+}
+
+/* Info panel activity notice */
+._3eus {
+  color: #DCDCCC !important;
+}


### PR DESCRIPTION
The group/person name at the top of the screen and the activity notice in the info panel maintain the darker colour, making it harder to read on the background. This edit makes the font the same colour as the text bubble font.