### PR TITLE
Fix/performance tweaks

### DIFF
--- a/src/components/dispatcher.js
+++ b/src/components/dispatcher.js
@@ -1,7 +1,8 @@
 var callbacks = {};
 var queue = [];
+var pendingTimeout = 0;
 
-setInterval(function() {
+var drain = function() {
   while (queue.length) {
     var event = queue[0][0];
     var data = queue[0][1];
@@ -12,7 +13,8 @@ setInterval(function() {
 
     queue.splice(0, 1);
   }
-}, 100);
+  pendingTimeout = 0
+};
 
 /**
  * Like an EventEmitter, but runs differently. Workaround for dialog crashes. Singleton.
@@ -32,5 +34,8 @@ module.exports = {
 
   trigger: function(event, data) {
     queue.push([event, data]);
+	if(!pendingTimeout) {
+		pendingTimeout = setTimeout(drain, 100)
+	}
   }
 };

--- a/src/components/window-behaviour.js
+++ b/src/components/window-behaviour.js
@@ -139,7 +139,7 @@ module.exports = {
         var extension = platform.isOSX ? '.tiff' : '.png';
         win.tray.icon = 'images/icon_' + type + alert + extension;
       }
-    }, 100);
+    }, 1000);
   },
 
   /**

--- a/src/components/window-behaviour.js
+++ b/src/components/window-behaviour.js
@@ -3,6 +3,8 @@ var platform = require('./platform');
 var settings = require('./settings');
 var utils = require('./utils');
 
+var lastLabel = '';
+
 module.exports = {
   /**
    * Update the behaviour of the given window object.
@@ -119,7 +121,15 @@ module.exports = {
           return;
         }
       }
-
+	  
+	  if(label == lastLabel) {
+		  // The label is no different to the last time it was set 
+		  // So don't bother invoking the win.set method.
+		  return;
+	  }
+	
+	  // Track the label for debouncing. 
+	  lastLabel = label;
       win.setBadgeLabel(label);
 
       // Update the tray icon too


### PR DESCRIPTION
I noticed a high CPU usage for M4D. Doing some profiling, the biggest impacts were setInterval(..., 100). I felt that nothing in Messenger needed to be updated that frequently. So made some tweaks and the performance seems to be significantly better.

* The dispatch loop is summoned when it goes from empty to not empty. It does not run constantly.
* The badge label is only set when it's different from the last time it was set
* The badge label is only checked once per second (setBadgeLabel had the highest CPU usage)

This brings the average CPU usage down from 14% to 1%. 

I don't feel that anything is broken by this, but if users would like to test that the badge label and dispatcher work as expected, that would be appreciated. 