### PR TITLE
Feature/Reload after PC sleep

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ var settings = require('./components/settings');
 var windowBehaviour = require('./components/window-behaviour');
 var notification = require('./components/notification');
 var dispatcher = require('./components/dispatcher');
+var utils = require('./components/utils');
 
 // Ensure there's an app shortcut for toast notifications to work on Windows
 if (platform.isWindows) {
@@ -49,6 +50,9 @@ if (platform.isWindows) {
 windowBehaviour.set(win);
 windowBehaviour.setNewWinPolicy(win);
 
+// Watch the system clock for computer coming out of sleep
+utils.watchComputerWake(win, windowBehaviour);
+
 // Inject logic into the app when it's loaded
 var iframe = document.querySelector('iframe');
 iframe.onload = function() {
@@ -71,11 +75,5 @@ iframe.onload = function() {
   windowBehaviour.closeWithEscKey(win, iframe.contentDocument);
 };
 
-// Reload the app periodically until it loads
-var reloadIntervalId = setInterval(function() {
-  if (win.window.navigator.onLine) {
-    clearInterval(reloadIntervalId);
-  } else {
-    win.reload();
-  }
-}, 10 * 1000);
+// Reload the app periodically until it's in online state.
+utils.checkForOnline(win);

--- a/src/app.js
+++ b/src/app.js
@@ -51,7 +51,7 @@ windowBehaviour.set(win);
 windowBehaviour.setNewWinPolicy(win);
 
 // Watch the system clock for computer coming out of sleep
-utils.watchComputerWake(win, windowBehaviour);
+utils.watchComputerWake(win, windowBehaviour, document);
 
 // Inject logic into the app when it's loaded
 var iframe = document.querySelector('iframe');

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -14,5 +14,40 @@ module.exports = {
     }
 
     return url;
+  },
+  /**
+   * Reload when computer wakes up
+   * Tracks time difference, if the difference is greater than 3 minutes. The window reloads
+   * If we know how long Messenger's session takes to timeout, perhaps use that time instead?
+   */
+  watchComputerWake: function(win, winBehaviour) {
+    var time = new Date().getTime();
+    setInterval(function() {
+      var currentTime = new Date().getTime();
+      var deltaTime = currentTime - time;
+      if (deltaTime > 60000 * 3) {  // Time in ms. 3 minutes.
+        // Do the reload
+        winBehaviour.saveWindowState(win);
+        win.reload();
+        /**
+         * Rerun the online check.
+         * We might have changed locations and no longer have internet access
+         */
+        this.checkForOnline(win);
+      }
+	  time = currentTime;
+    }, 1000);  // When the window is backgrounded, all functions run once per second.
+  },
+  /**
+   * Reloads the app once every 10 seconds until the browser is in online mode.
+   */
+  checkForOnline: function(win) {
+    var reloadIntervalId = setInterval(function() {
+      if (win.window.navigator.onLine) {
+        clearInterval(reloadIntervalId);
+      } else {
+        win.reload();
+      }
+    }, 10 * 1000);
   }
 };

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -16,17 +16,38 @@ module.exports = {
     return url;
   },
   /**
-   * Reload when computer wakes up
-   * Tracks time difference, if the difference is greater than 3 minutes. The window reloads
+   * Reload when computer wakes up.
+   * Tracks time difference, if the difference is greater than 3 minutes. The window reloads.
    * If we know how long Messenger's session takes to timeout, perhaps use that time instead?
+   * 
+   * Notes:
+   *   V8 caches date information, the current minute is updated at most, once per minute.
+   *   This means if the system time jumps, it might take up to a minute before the time is
+   *   represented by new Date().
+   *
+   *   It is unknown how often the hour is updated, but assumed that it is checked also once
+   *   per minute and not cached for longer. 
+   *
+   *   The absolute local time difference is tracked, this will cause MFD to reload when you
+   *   cross timezones also. This may or may not be desired, and could be fixed using
+   *   getTimezoneOffset(), or using UTC time.
+   *
+   *   Although it's unlikely that the time will result in a reload more than once a minute
+   *   due to time caching, it's possible that the bug/feature might be resolved in the future.
+   *   It's because of that motivation that the timeout remains at once per second. If the time
+   *   is cached, there is no performance impact, and if in the future it isn't cached. We can
+   *   profile and fix it at a later time. Overall a quick refresh means we reload as fast as
+   *   V8 will let us.
    */
-  watchComputerWake: function(win, winBehaviour) {
+  watchComputerWake: function(win, winBehaviour, document) {
     var time = new Date().getTime();
     setInterval(function() {
       var currentTime = new Date().getTime();
-      var deltaTime = currentTime - time;
+      var deltaTime = Math.abs(currentTime - time);
       if (deltaTime > 60000 * 3) {  // Time in ms. 3 minutes.
-        // Do the reload
+		// Remove the iframe to prevent interaction on an old session.
+		document.querySelector('iframe').remove();
+        // Save the window state and reload.
         winBehaviour.saveWindowState(win);
         win.reload();
         /**
@@ -36,7 +57,7 @@ module.exports = {
         this.checkForOnline(win);
       }
 	  time = currentTime;
-    }, 1000);  // When the window is backgrounded, all functions run once per second.
+    }, 1000);
   },
   /**
    * Reloads the app once every 10 seconds until the browser is in online mode.


### PR DESCRIPTION
Add a watchdog task that runs frequently to check for computer returning from sleep.

When the computer returns from sleep (measured by difference in time), the window is reloaded. Aids when sessions time out during sleep or hibernation.

Because timers run at a reduced rate when a task is backgrounded, the interval is set to 1s
This makes it a high priority against other interval tasks. In the future I'd like to implement
an extension to the dispatcher that runs a collection of tasks at an interval. Reducing this issue.