### PR TITLE
Added 'Facebook Unseen' component.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ var settings = require('./components/settings');
 var windowBehaviour = require('./components/window-behaviour');
 var notification = require('./components/notification');
 var dispatcher = require('./components/dispatcher');
+var blockSeen = require('./components/block-seen');
 var utils = require('./components/utils');
 
 // Add dispatcher events
@@ -84,6 +85,11 @@ iframe.onload = function() {
 		iframe.style.display = 'initial';
 	}
   });
+
+  // Block 'seen' and typing indicator
+  if (settings.blockSeen) {
+    blockSeen.set(true);
+  }
 
   dispatcher.trigger('online');
 };

--- a/src/components/block-seen.js
+++ b/src/components/block-seen.js
@@ -1,0 +1,31 @@
+var settings = require('./settings');
+
+var DEFAULT_URL_LIST = [
+  '*://*.facebook.com/*change_read_status*',
+  '*://*.messenger.com/*change_read_status*',
+  '*://*.facebook.com/*typ.php*',
+  '*://*.messenger.com/*typ.php*'
+];
+
+var requestHandler = function(details) {
+  return {
+    cancel: true
+  };
+};
+
+/**
+ * Enable or disable request blocking.
+ */
+module.exports = {
+  set: function(value) {
+    var blockSeen = Boolean(value);
+    if (blockSeen) {
+      chrome.webRequest.onBeforeRequest.addListener(requestHandler, {
+        urls: DEFAULT_URL_LIST
+      }, ['blocking']);
+    } else {
+      chrome.webRequest.onBeforeRequest.removeListener(requestHandler);
+    };
+    settings.updateKey('blockSeen', blockSeen);
+  }
+};

--- a/src/components/menus.js
+++ b/src/components/menus.js
@@ -6,6 +6,7 @@ var dispatcher = require('./dispatcher');
 var platform = require('./platform');
 var settings = require('./settings');
 var updater = require('./updater');
+var blockSeen = require('./block-seen');
 var utils = require('./utils');
 
 module.exports = {
@@ -99,6 +100,16 @@ module.exports = {
       type: 'checkbox',
       label: 'Start minimized',
       setting: 'startMinimized'
+    }, {
+      type: 'separator'
+    }, {
+      type: 'checkbox',
+      label: 'Block seen/typing indicators',
+      setting: 'blockSeen',
+      click: function() {
+        settings.blockSeen = this.checked;
+        blockSeen.set(this.checked);
+      }
     },	{
       type: 'separator'
     }, {

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -14,6 +14,7 @@ var DEFAULT_SETTINGS = {
   asMenuBarAppOSX: false,
   closeWithEscKey: false,
   startMinimized: false,
+  blockSeen: false,
   windowState: {},
   theme: 'default'
 };


### PR DESCRIPTION
I added a component (complete with settings and menu integration) which disables sending 'seen' and typing indicators, thus increasing privacy.

The feature is implemented by leveraging Chrome's webRequest API (see https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/onBeforeRequest) and blocking requests to the domains which handle the given Facebook platform features ('*://*.facebook.com/*change_read_status*','*://*.facebook.com/*typ.php*',).

Looking forward to your feedback.