### PR TITLE
Replace links to messengerfordesktop.com that installs MALWARE!

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![OS X build](https://travis-ci.org/aluxian/Messenger-for-Desktop.svg?branch=staging)](https://travis-ci.org/aluxian/Messenger-for-Desktop)
 [![Windows build](https://ci.appveyor.com/api/projects/status/2oar528hietbc77t/branch/staging?svg=true)](https://ci.appveyor.com/project/Aluxian/Messenger-for-Desktop)
 [![Linux builds](https://circleci.com/gh/aluxian/Messenger-for-Desktop/tree/staging.svg?style=shield)](https://circleci.com/gh/aluxian/Messenger-for-Desktop)
-[![Downloads total](https://updates.messengerfordesktop.com/badge/downloads.svg)](https://updates.messengerfordesktop.com/stats)
-[![Services status](https://img.shields.io/badge/services-status-blue.svg)](https://status.messengerfordesktop.com/)
+[![Downloads total](https://updates.messengerfordesktop.org/badge/downloads.svg)](https://updates.messengerfordesktop.org/stats)
+[![Services status](https://img.shields.io/badge/services-status-blue.svg)](https://status.messengerfordesktop.org/)
 [![Join the chat](https://badges.gitter.im/Join%20Chat.svg)][1]
 
 A simple &amp; beautiful desktop client for [Facebook Messenger](https://www.messenger.com/). Chat without distractions on OS X, Windows and Linux. Not affiliated with Facebook. This is **NOT** an official product.

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "lint-js": "eslint src/scripts"
   },
   "license": "MIT",
-  "author": "MessengerForDesktop.com <hello@messengerfordesktop.com>",
-  "homepage": "https://messengerfordesktop.com/",
+  "author": "MessengerForDesktop.com <hello@messengerfordesktop.org>",
+  "homepage": "https://messengerfordesktop.org/",
   "repository": {
     "type": "git",
     "url": "https://github.com/aluxian/Messenger-for-Desktop.git"

--- a/resources/win/eula.txt
+++ b/resources/win/eula.txt
@@ -1,4 +1,4 @@
-This End-User License Agreement (EULA) is a legal agreement between you (either as an individual or on behalf of an entity) and The Cofounders Ltd, Seychelles regarding your use of Messenger for Desktop for OS X, Windows and Linux and associated documentation (the "Software"). This EULA includes the Terms and Conditions (https://messengerfordesktop.com/terms.html) and Privacy Policy (https://messengerfordesktop.com/privacy.html). IF YOU DO NOT AGREE TO ALL OF THE TERMS OF THIS EULA, DO NOT INSTALL, USE OR COPY THE SOFTWARE.
+This End-User License Agreement (EULA) is a legal agreement between you (either as an individual or on behalf of an entity) and The Cofounders Ltd, Seychelles regarding your use of Messenger for Desktop for OS X, Windows and Linux and associated documentation (the "Software"). This EULA includes the Terms and Conditions (https://messengerfordesktop.org/terms.html) and Privacy Policy (https://messengerfordesktop.org/privacy.html). IF YOU DO NOT AGREE TO ALL OF THE TERMS OF THIS EULA, DO NOT INSTALL, USE OR COPY THE SOFTWARE.
 
 Summary
 You must agree to all of the terms of this EULA to use this Software.
@@ -55,6 +55,6 @@ This EULA constitutes the entire agreement between you and The Cofounders Ltd, S
 
 You agree that this EULA and your use of the Software are governed under Romanian law and any dispute related to the Software must be brought in a tribunal of competent jurisdiction located in or near Bucharest, Romania.
 
-Please send any questions about this EULA to hello@messengerfordesktop.com.
+Please send any questions about this EULA to hello@messengerfordesktop.org.
 
 The last update to this EULA was posted on December 17, 2016.

--- a/src/package.json
+++ b/src/package.json
@@ -43,10 +43,10 @@
     }
   },
   "packages": {
-    "osx64": "https://updates.messengerfordesktop.com/download/darwin/latest",
-    "win32": "https://updates.messengerfordesktop.com/download/win32/latest",
-    "linux32": "https://updates.messengerfordesktop.com/download/linux/latest?arch=i386&pkg=deb",
-    "linux64": "https://updates.messengerfordesktop.com/download/linux/latest?arch=amd64&pkg=deb"
+    "osx64": "https://updates.messengerfordesktop.org/download/darwin/latest",
+    "win32": "https://updates.messengerfordesktop.org/download/win32/latest",
+    "linux32": "https://updates.messengerfordesktop.org/download/linux/latest?arch=i386&pkg=deb",
+    "linux64": "https://updates.messengerfordesktop.org/download/linux/latest?arch=amd64&pkg=deb"
   },
   "darwin": {
     "bundleId": "com.aluxian.messengerfd",
@@ -59,16 +59,16 @@
     "section": "web"
   },
   "license": "MIT",
-  "author": "MessengerForDesktop.com <hello@messengerfordesktop.com>",
+  "author": "MessengerForDesktop.com <hello@messengerfordesktop.org>",
   "authorName": "MessengerForDesktop.com",
   "copyright": "Copyright © MessengerForDesktop.com",
-  "homepage": "https://messengerfordesktop.com",
+  "homepage": "https://messengerfordesktop.org",
   "repository": {
     "type": "git",
     "url": "https://github.com/aluxian/Messenger-for-Desktop.git"
   },
   "changelogUrl": "https://github.com/aluxian/Messenger-for-Desktop/releases/tag/v%CURRENT_VERSION%",
-  "virtualUrl": "http://app.messengerfordesktop.com",
+  "virtualUrl": "http://app.messengerfordesktop.org",
   "piwik": {
     "serverUrl": "{{& PIWIK_SERVER_URL }}",
     "siteId": "2"

--- a/src/scripts/browser/menus/templates/main-bots.js
+++ b/src/scripts/browser/menus/templates/main-bots.js
@@ -60,7 +60,7 @@ export default {
   }, {
     label: 'Discover More Bots',
     click () {
-      shell.openExternal('https://chatbottle.co/bots/messenger?ref=messengerfordesktop.com');
+      shell.openExternal('https://chatbottle.co/bots/messenger?ref=messengerfordesktop.org');
     }
   }]
 };

--- a/src/scripts/browser/menus/templates/main-help.js
+++ b/src/scripts/browser/menus/templates/main-help.js
@@ -5,7 +5,7 @@ export default {
   submenu: [{
     label: 'Open App Website',
     click () {
-      shell.openExternal('https://messengerfordesktop.com/');
+      shell.openExternal('https://messengerfordesktop.org/');
     }
   }, {
     label: 'Send Feedback',


### PR DESCRIPTION
It's very critical! Current source code references to messengerfordesktop.com that installs malware.

It must be merged and released as soon as possible.